### PR TITLE
Allow projects to build off of MAS network

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "requirejs": "2.1.11",
-    "scribe": "git@github.com:moneyadviceservice/scribe.git",
+    "scribe": "https://github.com/moneyadviceservice/scribe.git",
     "scribe-plugin-blockquote-command": "0.1.0",
     "scribe-plugin-curly-quotes": "0.1.2",
     "scribe-plugin-formatter-plain-text-convert-new-lines-to-html": "0.1.1",


### PR DESCRIPTION
We need to deploy a non-production branch to Heroku for a throw away prototype for the last round of user testing this week. One of our dependencies, for when we're going through the MAS pipeline, is the mas-cms-editor. This uses scribe which has an SSH-style git address rather than an HTTPS one, and so non-MAS services such as Heroku can't install it.

If it's ok to do so it would be good to have this PR merged so we don't hit this in future. If you'd rather not merge it _PLEASE DO NOT DELETE THIS BRANCH_ yet as we need it over the next few days in order to deploy to Heroku. We can then bin this PR and branch at the end of the week if you'd rather not merge.
